### PR TITLE
PersistentQueue support for multiple dequeue

### DIFF
--- a/src/Queue/PersistentQueue.php
+++ b/src/Queue/PersistentQueue.php
@@ -42,19 +42,18 @@ class PersistentQueue implements \IteratorAggregate, Queue
         return new self($this->forwards, $this->backwards->push($value), $this->count + 1);
     }
 
-    public function dequeue()
-    {
+    public function dequeue() {
         $f = $this->forwards->pop();
 
-        if ($f->isEmpty()) {
-            return new self($f, $this->backwards, $this->count - 1);
-        }
-
-        if ($this->backwards->isEmpty()) {
+        if ($f->isEmpty() && $this->backwards->isEmpty()) {
             return self::createEmpty();
         }
 
-        return new self($this->reversedBackwards(), PersistentStack::createEmpty(), $this->count - 1);
+        if ($f->isEmpty()) {
+            return new self($this->reversedBackwards(), PersistentStack::createEmpty(), $this->count - 1);
+        }
+
+        return new self($f, $this->backwards, $this->count - 1);
     }
 
     private function reversedBackwards()

--- a/tests/Queue/PersistentQueueTest.php
+++ b/tests/Queue/PersistentQueueTest.php
@@ -84,6 +84,19 @@ class PersistentQueueTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function dequeueShouldRemoveMoreThanOneElement()
+    {
+        $q = $this->createQueue([1, 2, 3, 4, 5]);
+
+        $q = $q->dequeue();
+        $q = $q->dequeue();
+
+        $this->assertValues([3, 4, 5], $q);
+    }
+
+    /**
+     * @test
+     */
     public function enqueueShouldNotAffectPreviousVersions()
     {
         $s = PersistentQueue::createEmpty();


### PR DESCRIPTION
Hello, thanks for building such a great library.
I was looking at the source code and it seems that current implementation of PersistentQueue supports dequeueing only once and breaks on further dequeues.

The current implementation is 
```php
    public function dequeue()
    {
        $f = $this->forwards->pop();

        if ($f->isEmpty()) {
            return new self($f, $this->backwards, $this->count - 1);
        }

        if ($this->backwards->isEmpty()) {
            return self::createEmpty();
        }

        return new self($this->reversedBackwards(), PersistentStack::createEmpty(), $this->count - 1);
    }
```

and it seems that we should transfer `backwards` to `forwards` when `forwards` is empty.
I've added a test that reproduces the problem,

Regards.